### PR TITLE
chore: small linter fixes/improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "clean": "rimraf target buildcache docs coverage",
+    "lint:fix": "eslint -c src/test/lint/.eslintrc.json src --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "test": "concurrently 'npm:test:*'",
     "test:unit": "NODE_OPTIONS=\"--experimental-vm-modules\" jest --config=jest.config.json --runInBand",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "scripts": {
     "clean": "rimraf target buildcache docs coverage",
-    "lint:fix": "yarn lint --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "test": "concurrently 'npm:test:*'",
     "test:unit": "NODE_OPTIONS=\"--experimental-vm-modules\" jest --config=jest.config.json --runInBand",

--- a/src/main/ts/stages.ts
+++ b/src/main/ts/stages.ts
@@ -22,7 +22,7 @@ import {
 /**
  * Resolve bins.
  */
-export const resolveBins: TCallback = ({ ctx, temp, flags }) => {
+export const resolveBins: TCallback = ({ ctx, flags }) => {
   const yafManifest = getSelfManifest()
   ctx.bins = {
     yarn: getYarn(),

--- a/src/main/ts/util.ts
+++ b/src/main/ts/util.ts
@@ -1,7 +1,7 @@
 import type { StdioOptions } from 'node:child_process'
 import crypto from 'node:crypto'
 import { createRequire } from 'node:module'
-import path, { dirname, join, resolve } from 'node:path'
+import path, { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import os from 'node:os'
 

--- a/src/test/lint/.eslintrc.json
+++ b/src/test/lint/.eslintrc.json
@@ -3,7 +3,7 @@
   "rules": {},
   "overrides": [
     {
-      "files": ["src/test/ts/runner.ts", "src/main/ts/stages.ts"],
+      "files": ["src/test/ts/runner.ts", "src/main/ts/stages.ts", "src/test/ts/util.ts"],
       "rules": {
         "sonarjs/no-duplicate-string": "off",
         "@typescript-eslint/ban-ts-comment": "off"

--- a/src/test/ts/util.ts
+++ b/src/test/ts/util.ts
@@ -91,14 +91,14 @@ describe('util', () => {
         ],
         [{ exclude: [] }, ['exclude'], []],
         [
-          { exclude: ['@scope/package'] }, // eslint-disable-line sonarjs/no-duplicate-string
+          { exclude: ['@scope/package'] },
           ['exclude'],
           ['--exclude', '@scope/package'],
         ],
         [
-          { exclude: ['@scope/package', 'another-package'] },
+          { exclude: ['@scope/package1', 'package2'] },
           ['exclude'],
-          ['--exclude', '@scope/package', '--exclude', 'another-package'],
+          ['--exclude', '@scope/package1', '--exclude', 'package2'],
         ],
         [{ verbose: true, exclude: [] }, [], ['--verbose']],
       ]


### PR DESCRIPTION
## Description
This PR purpose a few linter fixes:
- Suggest different `lint:fix` command, as the current command throws _command "lint" not found._ error.
- Fix `sonarjs/no-duplicate-string` linter error introduced by #345 without disabling the error for the line.
- Fix couple of `@typescript-eslint/no-unused-vars` linter warnings.